### PR TITLE
use cl-% prefix for cl-lib functions

### DIFF
--- a/slime-docker.el
+++ b/slime-docker.el
@@ -542,9 +542,9 @@ MOUNTS is the mounts description Docker was started with."
 (defun slime-docker--canonicalize-mounts (mounts)
   "Canonicalize the mount names from MOUNTS."
   (mapcar (lambda (x)
-            (cl-list* (cons (expand-file-name (car (first x)))
-                            (cdr (first x)))
-                      (rest x)))
+            (cl-list* (cons (expand-file-name (car (cl-first x)))
+                            (cdr (cl-first x)))
+                      (cl-rest x)))
           mounts))
 
 ;;;; User interaction


### PR DESCRIPTION
Seems like the library is still using functions (`first`, `rest`) from `cl`, even though `cl-lib` is loaded.

I guess I did not have `cl` loaded in Emacs and was getting this error: 

```Symbols's function definition is void: first```